### PR TITLE
File locking and token functions

### DIFF
--- a/advapi32.go
+++ b/advapi32.go
@@ -51,6 +51,9 @@ var (
 	procOpenProcessToken      = modadvapi32.NewProc("OpenProcessToken")
 	procLookupPrivilegeValue  = modadvapi32.NewProc("LookupPrivilegeValueW")
 	procAdjustTokenPrivileges = modadvapi32.NewProc("AdjustTokenPrivileges")
+	procGetTokenInformation   = modadvapi32.NewProc("GetTokenInformation")
+	procCreateWellKnownSid    = modadvapi32.NewProc("CreateWellKnownSid")
+	procCheckTokenMembership  = modadvapi32.NewProc("CheckTokenMembership")
 )
 
 func RegCreateKey(hKey HKEY, subKey string) HKEY {
@@ -488,4 +491,220 @@ func AdjustTokenPrivileges(hToken HANDLE, disableAllPrivileges bool, newState TO
 		uintptr(0))
 
 	return ret != 0
+}
+
+type TokenInformationClass byte
+
+const (
+	InvalidTokenInfoClass TokenInformationClass = iota
+	TokenUser
+	TokenGroups
+	TokenPrivileges
+	TokenOwner
+	TokenPrimaryGroup
+	TokenDefaultDacl
+	TokenSource
+	TokenType
+	TokenImpersonationLevel
+	TokenStatistics
+	TokenRestrictedSids
+	TokenSessionId
+	TokenGroupsAndPrivileges
+	TokenSessionReference
+	TokenSandBoxInert
+	TokenAuditPolicy
+	TokenOrigin
+	TokenElevationType
+	TokenLinkedToken
+	TokenElevation
+	TokenHasRestrictions
+	TokenAccessInformation
+	TokenVirtualizationAllowed
+	TokenVirtualizationEnabled
+	TokenIntegrityLevel
+	TokenUIAccess
+	TokenMandatoryPolicy
+	TokenLogonSid
+	TokenIsAppContainer
+	TokenCapabilities
+	TokenAppContainerSid
+	TokenAppContainerNumber
+	TokenUserClaimAttributes
+	TokenDeviceClaimAttributes
+	TokenRestrictedUserClaimAttributes
+	TokenRestrictedDeviceClaimAttributes
+	TokenDeviceGroups
+	TokenRestrictedDeviceGroups
+	TokenSecurityAttributes
+	TokenIsRestricted
+	MaxTokenInfoClass
+)
+
+type TokenElevationTypeResult uint32
+
+const (
+	TokenElevationTypeDefault TokenElevationTypeResult = 1
+	TokenElevationTypeFull                             = 2
+	TokenElevationTypeLimited                          = 3
+)
+
+// returns ptr to appropriate Token*Result struct, or nil if error
+func GetTokenInformation(hToken HANDLE, tokenInfoClass TokenInformationClass) interface{} {
+	switch tokenInfoClass {
+	case TokenElevationType:
+		var res TokenElevationTypeResult
+		expectedLength := uint32(unsafe.Sizeof(res))
+		retLength := uint32(0)
+		ret, _, _ := procGetTokenInformation.Call(
+			uintptr(hToken),
+			uintptr(tokenInfoClass),
+			uintptr(unsafe.Pointer(&res)),
+			uintptr(expectedLength),
+			uintptr(unsafe.Pointer(&retLength)))
+		if ret != 0 && retLength == expectedLength &&
+			res >= TokenElevationTypeDefault && res <= TokenElevationTypeLimited {
+			return &res
+		}
+	case TokenLinkedToken:
+		var res HANDLE
+		expectedLength := uint32(unsafe.Sizeof(res))
+		retLength := uint32(0)
+		ret, _, _ := procGetTokenInformation.Call(
+			uintptr(hToken),
+			uintptr(tokenInfoClass),
+			uintptr(unsafe.Pointer(&res)),
+			uintptr(expectedLength),
+			uintptr(unsafe.Pointer(&retLength)))
+		if ret != 0 && retLength == expectedLength {
+			return res
+		}
+	}
+	return nil
+}
+
+type WellKnownSidType byte
+
+const (
+	WinNullSid                                  WellKnownSidType = 0
+	WinWorldSid                                                  = 1
+	WinLocalSid                                                  = 2
+	WinCreatorOwnerSid                                           = 3
+	WinCreatorGroupSid                                           = 4
+	WinCreatorOwnerServerSid                                     = 5
+	WinCreatorGroupServerSid                                     = 6
+	WinNtAuthoritySid                                            = 7
+	WinDialupSid                                                 = 8
+	WinNetworkSid                                                = 9
+	WinBatchSid                                                  = 10
+	WinInteractiveSid                                            = 11
+	WinServiceSid                                                = 12
+	WinAnonymousSid                                              = 13
+	WinProxySid                                                  = 14
+	WinEnterpriseControllersSid                                  = 15
+	WinSelfSid                                                   = 16
+	WinAuthenticatedUserSid                                      = 17
+	WinRestrictedCodeSid                                         = 18
+	WinTerminalServerSid                                         = 19
+	WinRemoteLogonIdSid                                          = 20
+	WinLogonIdsSid                                               = 21
+	WinLocalSystemSid                                            = 22
+	WinLocalServiceSid                                           = 23
+	WinNetworkServiceSid                                         = 24
+	WinBuiltinDomainSid                                          = 25
+	WinBuiltinAdministratorsSid                                  = 26
+	WinBuiltinUsersSid                                           = 27
+	WinBuiltinGuestsSid                                          = 28
+	WinBuiltinPowerUsersSid                                      = 29
+	WinBuiltinAccountOperatorsSid                                = 30
+	WinBuiltinSystemOperatorsSid                                 = 31
+	WinBuiltinPrintOperatorsSid                                  = 32
+	WinBuiltinBackupOperatorsSid                                 = 33
+	WinBuiltinReplicatorSid                                      = 34
+	WinBuiltinPreWindows2000CompatibleAccessSid                  = 35
+	WinBuiltinRemoteDesktopUsersSid                              = 36
+	WinBuiltinNetworkConfigurationOperatorsSid                   = 37
+	WinAccountAdministratorSid                                   = 38
+	WinAccountGuestSid                                           = 39
+	WinAccountKrbtgtSid                                          = 40
+	WinAccountDomainAdminsSid                                    = 41
+	WinAccountDomainUsersSid                                     = 42
+	WinAccountDomainGuestsSid                                    = 43
+	WinAccountComputersSid                                       = 44
+	WinAccountControllersSid                                     = 45
+	WinAccountCertAdminsSid                                      = 46
+	WinAccountSchemaAdminsSid                                    = 47
+	WinAccountEnterpriseAdminsSid                                = 48
+	WinAccountPolicyAdminsSid                                    = 49
+	WinAccountRasAndIasServersSid                                = 50
+	WinNTLMAuthenticationSid                                     = 51
+	WinDigestAuthenticationSid                                   = 52
+	WinSChannelAuthenticationSid                                 = 53
+	WinThisOrganizationSid                                       = 54
+	WinOtherOrganizationSid                                      = 55
+	WinBuiltinIncomingForestTrustBuildersSid                     = 56
+	WinBuiltinPerfMonitoringUsersSid                             = 57
+	WinBuiltinPerfLoggingUsersSid                                = 58
+	WinBuiltinAuthorizationAccessSid                             = 59
+	WinBuiltinTerminalServerLicenseServersSid                    = 60
+	WinBuiltinDCOMUsersSid                                       = 61
+	WinBuiltinIUsersSid                                          = 62
+	WinIUserSid                                                  = 63
+	WinBuiltinCryptoOperatorsSid                                 = 64
+	WinUntrustedLabelSid                                         = 65
+	WinLowLabelSid                                               = 66
+	WinMediumLabelSid                                            = 67
+	WinHighLabelSid                                              = 68
+	WinSystemLabelSid                                            = 69
+	WinWriteRestrictedCodeSid                                    = 70
+	WinCreatorOwnerRightsSid                                     = 71
+	WinCacheablePrincipalsGroupSid                               = 72
+	WinNonCacheablePrincipalsGroupSid                            = 73
+	WinEnterpriseReadonlyControllersSid                          = 74
+	WinAccountReadonlyControllersSid                             = 75
+	WinBuiltinEventLogReadersGroup                               = 76
+	WinNewEnterpriseReadonlyControllersSid                       = 77
+	WinBuiltinCertSvcDComAccessGroup                             = 78
+	WinMediumPlusLabelSid                                        = 79
+	WinLocalLogonSid                                             = 80
+	WinConsoleLogonSid                                           = 81
+	WinThisOrganizationCertificateSid                            = 82
+	WinApplicationPackageAuthoritySid                            = 83
+	WinBuiltinAnyPackageSid                                      = 84
+	WinCapabilityInternetClientSid                               = 85
+	WinCapabilityInternetClientServerSid                         = 86
+	WinCapabilityPrivateNetworkClientServerSid                   = 87
+	WinCapabilityPicturesLibrarySid                              = 88
+	WinCapabilityVideosLibrarySid                                = 89
+	WinCapabilityMusicLibrarySid                                 = 90
+	WinCapabilityDocumentsLibrarySid                             = 91
+	WinCapabilitySharedUserCertificatesSid                       = 92
+	WinCapabilityEnterpriseAuthenticationSid                     = 93
+	WinCapabilityRemovableStorageSid                             = 94
+)
+
+type SID []byte
+
+const SECURITY_MAX_SID_SIZE = 68
+
+func CreateWellKnownSid(wks WellKnownSidType) SID {
+	sid := make([]byte, SECURITY_MAX_SID_SIZE+1)
+	sidLen := uint32(len(sid))
+	ret, _, _ := procCreateWellKnownSid.Call(
+		uintptr(wks),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&sid[0])),
+		uintptr(unsafe.Pointer(&sidLen)))
+	if ret != 0 && sidLen > 0 && sidLen <= SECURITY_MAX_SID_SIZE {
+		return SID(sid[:sidLen])
+	}
+	return nil
+}
+
+func CheckTokenMembership(hToken HANDLE, sidToCheck SID) bool {
+	isMember := uint32(9)
+	ret, _, _ := procCheckTokenMembership.Call(
+		uintptr(hToken),
+		uintptr(unsafe.Pointer(&sidToCheck[0])),
+		uintptr(unsafe.Pointer(&isMember)))
+	return ret != 0 && isMember == 1
 }

--- a/kernel32.go
+++ b/kernel32.go
@@ -470,6 +470,7 @@ func WaitForSingleObject(object HANDLE, msWait uint32) uint32 {
 	}
 }
 
+// LockFile will fail immediately (ret false) when it's not able to acquire lock.
 func LockFile(hFile HANDLE, fileOffset uint64, numberOfBytesToLock uint64) bool {
 	ret, _, _ := procLockFile.Call(
 		uintptr(hFile),
@@ -482,6 +483,8 @@ func LockFile(hFile HANDLE, fileOffset uint64, numberOfBytesToLock uint64) bool 
 
 const LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
 
+// LockFileEx currently only works in exclusive + blocking mode. It won't return
+// until lock is acquired (ret true) or an error occurred (ret false).
 func LockFileEx(hFile HANDLE, fileOffset uint64, numberOfBytesToLock uint64) bool {
 	lpvo := &syscall.Overlapped{Offset: uint32(fileOffset), OffsetHigh: uint32(fileOffset >> 32)}
 	ret, _, _ := procLockFileEx.Call(


### PR DESCRIPTION
This PR adds the following functions:
- kernel32:  GetVersion, LockFile, LockFileEx, and UnlockFile.
- advapi32: GetTokenInformation, CreateWellKnownSid and CheckTokenMembership.

GetTokenInformation() returns ~40 different types depending on TokenInformationClass.  This PR implements only two: TokenElevationType and TokenLinkedToken.

@potocnyj could you please review?
